### PR TITLE
Fix method signatures for PHP 7.0 compatibility

### DIFF
--- a/action.php
+++ b/action.php
@@ -15,13 +15,13 @@ class action_plugin_svgedit extends DokuWiki_Action_Plugin {
                          'url'    => 'http://www.dokuwiki.org/plugin:svgedit'
                  );
 		}
- 
-    function register(&$controller) {
+
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this,
                                    '_hookdo');
     }
- 
-    function _hookdo(&$event, $param) {
+
+    function _hookdo(Doku_Event $event, $param) {
 			global $ID;
       if($event->data === 'export_svg' && auth_quickaclcheck($ID) >= AUTH_READ) {
 				header('Content-type: image/svg+xml');

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   svgedit
 author Thomas Mudrunka
 email  harvie[a]email_cz
-date   2014-05-20
+date   2016-01-16
 name   SVG-Edit plugin
 desc   A nice way, to create, store, edit, and embed SVG images in DokuWiki
 url    http://www.dokuwiki.org/plugin:svgedit

--- a/syntax.php
+++ b/syntax.php
@@ -43,7 +43,7 @@ class syntax_plugin_svgedit extends DokuWiki_Syntax_Plugin {
 				$this->Lexer->addSpecialPattern("<svg.+?</svg>", $mode, 'plugin_svgedit');
     } 
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
 				$type = substr($match,0,4);
         return array($type, $match); 
     }
@@ -64,7 +64,7 @@ class syntax_plugin_svgedit extends DokuWiki_Syntax_Plugin {
 				return '<a href="'.$svglink.'" type="image/svg+xml" /><'.$svgtag.'="'.$svglink.'" class="media'.$align.'" alt="'.$title.'" title="'.$title.'" type="image/svg+xml">'."</$svgtag_close></a>";
 		}
 
-    function render($format, &$renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data) {
 				if ($format!='xhtml') return;
 				global $ID;
 


### PR DESCRIPTION
I have not tested if everything works, but this should not break anything either and definitely fixes warnings under PHP 7.0.